### PR TITLE
Fix defaultValue for boolean radio group

### DIFF
--- a/forms/src/fields/input-fields.tsx
+++ b/forms/src/fields/input-fields.tsx
@@ -90,7 +90,13 @@ export const KdBooleanRadioGroup =
   ({ field, context }: FieldProps) => {
     return (
       <RadioGroup
-        defaultValue={field.value ? "true" : "false"}
+        defaultValue={
+          field.value === true
+            ? "true"
+            : field.value === false
+              ? "false"
+              : field.value
+        }
         onValueChange={field.onChange}
         className="ktw-flex ktw-flex-col ktw-space-y-1 k ktw-pl-4"
       >


### PR DESCRIPTION
Radio group inputs (the native element) only support string values, which we set to "true" and "false"

It's possible (and useful) to use a zod schema that preprocesses these values into an actual boolean value, so that it can be stored as such in a db

.. but we can't guarantee that will happen from the control, so we need to handle both boolean and string form values correctly